### PR TITLE
Maintain a history of all shipments made

### DIFF
--- a/aliases.miniscot
+++ b/aliases.miniscot
@@ -1,0 +1,8 @@
+alias create nodes print nodes
+alias create edges print edges
+alias create orders print orders
+alias create cohist print order_hist
+alias create pohist print po_hist
+alias create inbounds print inbound_shipments
+alias create outbounds print outbound_shipments
+alias create transfers print transfer_shipments

--- a/src/scse/controller/miniscot.py
+++ b/src/scse/controller/miniscot.py
@@ -6,6 +6,8 @@ import logging
 import networkx as nx
 import datetime
 import time
+from collections import defaultdict
+
 from scse.api.module import Agent
 from scse.api.module import Env
 from scse.utils.printer import red
@@ -84,6 +86,13 @@ class SupplyChainEnvironment:
         # TODO Should we treat this as context or state?
         state['customer_orders'] = []
         state['purchase_orders'] = []
+
+        # Keep a history of order, shipments and history
+        state['customer_order_history'] = defaultdict(list)
+        state['purchase_order_history'] = defaultdict(list)
+        state['inbound_shipment_history'] = defaultdict(list)
+        state['outbound_shipment_history'] = defaultdict(list)
+        state['transfer_history'] = defaultdict(list)
 
         # The final Env is made of contributions from Env-modules. Each
         # Env-module can provide (static) context and the initial values for
@@ -258,6 +267,8 @@ class SupplyChainEnvironment:
         state, action = self._remove_order_entity(state, action)      
         # either way, append new order to state
         state[atype_to_state].append(action)
+        # keep a history of all orders made
+        state[f'{action["type"]}_history'][state['clock']].append(action)
 
         return state
 
@@ -307,6 +318,9 @@ class SupplyChainEnvironment:
 
 
         shipments.append(shipment)
+
+        # keep a history of all shipments made
+        state[f'{atype}_history'][state['clock']].append(shipment)
 
         return state
 

--- a/src/scse/main/cli.py
+++ b/src/scse/main/cli.py
@@ -4,6 +4,9 @@ import argparse
 import cmd2
 import pprint
 import networkx as nx
+from itertools import cycle
+from collections import defaultdict
+import matplotlib.pyplot as plt
 from scse.controller import miniscot as miniSCOT
 
 class MiniSCOTDebuggerApp(cmd2.Cmd):
@@ -88,8 +91,18 @@ class MiniSCOTDebuggerApp(cmd2.Cmd):
             msg = pprint.pformat(self._actions)
         elif args == 'orders':
             msg = pprint.pformat(self._state['customer_orders'])
+        elif args == 'order_hist':
+            msg = pprint.pformat(self._state['customer_order_history'])
         elif args == "POs":
             msg = pprint.pformat(self._state['purchase_orders'])
+        elif args == 'po_hist':
+            msg = pprint.pformat(self._state['purchase_order_history'])
+        elif args == 'inbound_shipments':
+            msg = pprint.pformat(self._state['inbound_shipment_history'])
+        elif args == 'outbound_shipments':
+            msg = pprint.pformat(self._state['outbound_shipment_history'])
+        elif args == 'transfer_shipments':
+            msg = pprint.pformat(self._state['transfer_shipment_history'])
         elif args == "reward":
             msg = pprint.pformat(self._reward)
         else:

--- a/src/scse/modules/vendor/demo_newsvendor_infinite_inventory.py
+++ b/src/scse/modules/vendor/demo_newsvendor_infinite_inventory.py
@@ -46,6 +46,10 @@ class InfiniteInventoryVendor(Agent):
             ## Complete action_form with the origin node, confirm the quantity we can fulfill,
             ## and schedule when it ships (e.g. 2 timesteps from now)
 
+            logger.debug("Fulfilling PO for {} quantity of ASIN {} to warehouse {}.".format(
+                po['quantity'], po['asin'], closest_warehouse_name)
+                )
+
             action = {
                 'type': 'inbound_shipment',
                 'asin': po['asin'],


### PR DESCRIPTION
Keep a history of all the shipments that have been made at each timestep. Also create a selection of timesaving aliases which can be loaded by running:

`run_script aliases.miniscot`