### PR TITLE
Network visualisation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ setup(
         'docker == 5.0.3',
         'requests == 2.26.0',
         'gym == 0.21.0',
+        'matplotlib==3.5.1',
     ],
     setup_requires=[
         'pytest-runner',


### PR DESCRIPTION
Add `visualise` command to miniscot. Will produce a network diagram similar to the following:

![image](https://user-images.githubusercontent.com/32013626/145983673-3b89d438-5d7a-4630-b752-cdea2426b223.png)

Numbers inside nodes indicate the total quantity of all products held; numbers on edges indicate the total quantity of all products currently in transit.