### PR TITLE
Initial simulation of the national grid

### DIFF
--- a/aliases.miniscot
+++ b/aliases.miniscot
@@ -6,3 +6,4 @@ alias create pohist print po_hist
 alias create inbounds print inbound_shipments
 alias create outbounds print outbound_shipments
 alias create transfers print transfer_shipments
+alias create debug set debug true

--- a/src/scse/controller/miniscot.py
+++ b/src/scse/controller/miniscot.py
@@ -254,6 +254,8 @@ class SupplyChainEnvironment:
             state['date_time'] += datetime.timedelta(days=1)
         elif self._time_increment == 'hourly':
             state['date_time'] += datetime.timedelta(hours=1)
+        elif self._time_increment == 'half-hourly':
+            state['date_time'] += datetime.timedelta(hours=0.5)
         else:
             raise ValueError("Unknown time increment arg".format(self._time_increment))
 
@@ -293,10 +295,10 @@ class SupplyChainEnvironment:
 
         # Update only after the other components have been retrieved to avoid
         # chances of corruption.
-        # assert origin_data["inventory"][asin] >= quantity
+        # assert origin_data["inventory"][asin] >= quantity, or `allow_negative` is True
         # vendors may not have a notion of inventory (e.g. maybe just confirmation rate)
         if 'inventory' in origin_data:
-            if quantity <= origin_data['inventory'][asin]:
+            if quantity <= origin_data['inventory'][asin] or origin_data.get('allow_negative', False):
                 origin_data['inventory'][asin] -= quantity
             else:
                 raise ValueError("Action tried to transfer {} units of {} from {} to {}, but {} only had {} units of inventory for this ASIN!".format(quantity, asin, origin, destination, origin, origin_data['inventory'][asin]))

--- a/src/scse/main/cli.py
+++ b/src/scse/main/cli.py
@@ -11,11 +11,11 @@ from scse.controller import miniscot as miniSCOT
 
 class MiniSCOTDebuggerApp(cmd2.Cmd):
     _DEFAULT_START_DATE = '2019-01-01'
-    _DEFAULT_TIME_INCREMENT = 'daily'
+    _DEFAULT_TIME_INCREMENT = 'half-hourly'
     _DEFAULT_HORIZON = 100
     _DEFAULT_SIMULATION_SEED = 12345
-    _DEFAULT_ASIN_SELECTION = 1 # or use an integer value to select the number of asins
-    _DEFAULT_PROFILE = 'newsvendor_demo_profile'
+    _DEFAULT_ASIN_SELECTION = 0 # or use an integer value to select the number of asins
+    _DEFAULT_PROFILE = 'national_grid_profile'
 
     def __init__(self, **args):
         super().__init__(args)

--- a/src/scse/modules/customer/national_grid_constant_demand.py
+++ b/src/scse/modules/customer/national_grid_constant_demand.py
@@ -1,0 +1,46 @@
+import logging
+
+from scse.api.module import Agent
+
+logger = logging.getLogger(__name__)
+
+
+class ConstantDemand(Agent):
+    _DEFAULT_AMOUNT = 10
+    _DEFAULT_ASIN = 'electricity'
+    _DEFAULT_CUSTOMER = 'Consumers'
+
+    def __init__(self, run_parameters):
+        """
+        Simulates time invariant electricity demand from a single customer.
+        """
+        self._amount = run_parameters.get('constant_demand_amount', self._DEFAULT_AMOUNT)
+        self._asin = run_parameters.get('constant_demand_asin', self._DEFAULT_ASIN)
+        self._customer = run_parameters.get('constant_demand_customer', self._DEFAULT_CUSTOMER)
+
+    def get_name(self):
+        return 'constant_demand'
+
+    def reset(self, context, state):
+        self._asin_list = context['asin_list']
+
+    def compute_actions(self, state):
+        """
+        Creates a single action/order for a constant amount of electricity.
+        """
+        actions = []
+
+        action = {
+            'type': 'customer_order',
+            'asin': self._asin,
+            'origin': None,  # The customer cannot request where the electricity comes from
+            'destination': self._customer,
+            'quantity': self._amount,
+            'schedule': state['clock']
+        }
+            
+        logger.debug(f"{self._customer} requested {self._amount} units of {self._asin}.")
+
+        actions.append(action)
+
+        return actions

--- a/src/scse/modules/fulfillment/national_grid_closest_substation_fulfillment.py
+++ b/src/scse/modules/fulfillment/national_grid_closest_substation_fulfillment.py
@@ -1,0 +1,77 @@
+import logging
+
+from scse.api.module import Agent
+
+logger = logging.getLogger(__name__)
+
+
+class ClosestSubstationFulfillment(Agent):
+    def __init__(self, run_parameters):
+        """
+        Customer orders for electricity are fulfilled by the nearest substation.
+        """
+        pass
+
+    def get_name(self):
+        return 'fulfiller'
+
+    def reset(self, context, state):
+        self._asin_list = context['asin_list']
+
+    def compute_actions(self, state):
+        """
+        Get locations of customer orders, match with closest substation, and fulfill the order.
+        """
+
+        actions = []
+        G = state['network']
+
+        # Get a list of substations - remember that these have the type `port` for now
+        # Distance information has been kept for potential future use
+        substations = {}
+        for node, node_data in G.nodes(data=True):
+            if node_data.get('node_type') == 'port':
+                substations[node] = {
+                    "location": node_data.get('location'),
+                }
+
+        # Error is thrown if there is not at least one substation
+        if not substations:
+            raise ValueError("No substations (i.e. ports) found - check the network topology.")
+        logger.debug(f"There are {len(substations)} substations")
+
+        # Loop through and fulfil customer orders
+        for order in state['customer_orders']:
+            asin = order['asin']
+            if asin != 'electricity':
+                raise ValueError("At present, only customer orders for generic electricity are supported.")
+
+            customer_id = order['destination']
+            customer_location = G.nodes[customer_id]['location']
+
+            # Determine the distance to each substation
+            substation_distances = {}
+            for substation in substations:
+                distance = _distance(substations[substation]['location'], customer_location)
+                substation_distances[substation] = distance
+            closest_substation = min(substation_distances.keys(), key=(lambda k: substation_distances[k]))
+
+            logger.debug(f"Fulfilling order {order} from substation {closest_substation}.")
+
+            action = {
+                'type': 'outbound_shipment',
+                'asin': asin,
+                'origin': closest_substation,
+                'destination': customer_id,
+                'schedule': order['schedule'],
+                'quantity': order['quantity'],
+                'uuid': order['uuid']
+            }
+
+            actions.append(action)
+
+        return actions
+
+
+def _distance(s, d):
+    return (s[0] - d[0])**2 + (s[1] - d[1])**2

--- a/src/scse/modules/selection/national_grid_selection.py
+++ b/src/scse/modules/selection/national_grid_selection.py
@@ -1,0 +1,45 @@
+import logging
+
+from scse.api.module import Env
+
+logger = logging.getLogger(__name__)
+
+
+class SourcesSelectionAgent(Env):
+    def __init__(self, run_parameters):
+        """
+        Types of electricity generation being modelled.
+        """
+        self._asin_selection = run_parameters['asin_selection']
+
+    def get_name(self):
+        return 'asin_list'
+
+    def get_context(self):
+        if isinstance(self._asin_selection, list):
+            asin_list = self._asin_selection
+        elif isinstance(self._asin_selection, int):
+            if self._asin_selection == 0:
+                # Default to return all supported electricity source types
+                asin_list = [
+                    "solar",
+                    "wind_onshore",
+                    "fossil_gas",
+                ]
+            else:
+                raise ValueError("""
+                National Grid profile does not accept selecting a subset of electricity
+                sources - set asin_selection run parameter to 0.
+                """)
+        else:
+            raise ValueError("""
+            National Grid profile selection reqires list (e.g. ['solar']) or 0 
+            asin_selection run parameter.
+            """)
+
+        # Add generic "electricity" to list
+        # This is what substations (aka ports) and batteries (aka warehouses) deal in
+        asin_list.append("electricity")
+
+        logger.debug(f"Electricity sources selected = {asin_list}.")
+        return asin_list

--- a/src/scse/modules/topology/national_grid_network.py
+++ b/src/scse/modules/topology/national_grid_network.py
@@ -1,0 +1,97 @@
+import networkx as nx
+from scse.api.module import Env
+
+
+class NationalGridNetwork(Env):
+    # Start with nothing, and allow 1 period for transit
+    # Technically transfer should be instantaneous, but lets cheat a bit
+    _DEFAULT_INITIAL_INVENTORY = 0
+    _DEFAULT_TRANSIT_TIME = 1
+
+    def __init__(self, run_parameters):
+        """
+        Highly simplified digital twin of the network.
+        """
+        self._initial_inventory = run_parameters.get('initial_inventory', self._DEFAULT_INITIAL_INVENTORY)
+        self._transit_time = run_parameters.get('transit_time', self._DEFAULT_TRANSIT_TIME)
+
+    def get_name(self):
+        return 'network'
+
+    def get_initial_state(self, context):
+        G = nx.DiGraph()
+        asin_list = context['asin_list']
+
+        ##############
+        # Define Nodes
+        ##############
+
+        # "Vendors": electricity sources
+        # These could be further broken down
+        # Have only added a subset for now
+        # Added `asins_produced` property
+        G.add_node("Solar",
+                    node_type = 'vendor',
+                    asins_produced = ['solar'],
+                    location = (0.0, 0.0)
+                    )
+        G.add_node("Wind Onshore",
+                    node_type = 'vendor',
+                    asins_produced = ['wind_onshore'],
+                    location = (0.1, 0.1)
+                    )
+        G.add_node("Fossil Gas",
+                    node_type = 'vendor',
+                    asins_produced = ['fossil_gas'],
+                    location = (0.2, 0.2)
+                    )
+
+        # "Port": electricity substations
+        # Could also define as warehouses, but provides differentiation
+        # Further analysis of how `node_type` is used required
+        # Only one for now - more can be added at later date
+        # Added `allow_negative` property
+        G.add_node("Substation",
+                    node_type = 'port',
+                    location = (1.0, 1.0),
+                    inventory = dict.fromkeys(asin_list, self._initial_inventory),
+                    allow_negative = True
+                    )
+
+        # "Warehouse": batteries
+        # Only one for now - more can be added at later date
+        G.add_node("Battery",
+                    node_type = 'warehouse',
+                    location = (2.0, 2.0),
+                    inventory = dict.fromkeys(asin_list, self._initial_inventory)
+                    )
+
+        # Consumers
+        # Only one for now - more can be added at later date
+        G.add_node("Consumers",
+                    node_type = 'customer',
+                    location = (0.0, 0.0),
+                    delivered = 0
+                    )
+
+        ##############
+        # Define Edges
+        ##############
+
+        # Electricity sources to substation
+        G.add_edge("Solar", "Substation", **{'transit_time': self._transit_time, 'shipments': []})
+        G.add_edge("Wind Onshore", "Substation", **{'transit_time': self._transit_time, 'shipments': []})
+        G.add_edge("Fossil Gas", "Substation", **{'transit_time': self._transit_time, 'shipments': []})
+
+        # Substation to battery
+        # Note: At later date may want to model direct source -> battery storage
+        G.add_edge("Substation", "Battery", **{'transit_time': self._transit_time, 'shipments': []})
+
+        # Battery to to substation
+        # Could use different substation to prevent cycle
+        G.add_edge("Battery", "Substation", **{'transit_time': self._transit_time, 'shipments': []})
+
+        # Substation to customer
+        G.add_edge("Substation", "Consumers", **{'transit_time': self._transit_time, 'shipments': []})
+
+        return G

--- a/src/scse/modules/topology/national_grid_network.py
+++ b/src/scse/modules/topology/national_grid_network.py
@@ -70,7 +70,7 @@ class NationalGridNetwork(Env):
         # Only one for now - more can be added at later date
         G.add_node("Consumers",
                     node_type = 'customer',
-                    location = (0.0, 0.0),
+                    location = (3.0, 3.0),
                     delivered = 0
                     )
 

--- a/src/scse/modules/vendor/national_grid_constant_supply.py
+++ b/src/scse/modules/vendor/national_grid_constant_supply.py
@@ -1,0 +1,69 @@
+from scse.api.module import Agent
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+class ConstantSupply(Agent):
+    _DEFAULT_AMOUNT = 10
+
+    def __init__(self, run_parameters):
+        """
+        Simulates time invariant electricity supply from all sources.
+        """
+        self._amount = self._DEFAULT_AMOUNT
+
+    def get_name(self):
+        return 'vendor'
+
+    def reset(self, context, state):
+        self._asin_list = context['asin_list']
+
+    def compute_actions(self, state):
+        """
+        Create constant supply from each source.
+        """
+        actions = []
+        current_time = state['date_time']
+        current_clock = state['clock']
+        
+        G = state['network']
+
+        # Get a list of substations - remember that these have the type `port` for now
+        substations = []
+        for node, node_data in G.nodes(data=True):
+            if node_data.get('node_type') == 'port':
+                substations.append(node)
+        
+        if len(substations) == 0:
+            raise ValueError('Could not identify any substations.')
+        elif len(substations) > 1:
+            raise ValueError('Identified multiple substations - this is not yet supported.')
+        
+        substation = substations[0]
+
+        # Create shipment from every vendor (i.e. electricity supply) to substation
+        for node, node_data in G.nodes(data=True):
+            if node_data.get('node_type') == 'vendor':
+                # Determine how the vendor produces electricity
+                generation_types = node_data.get('asins_produced')
+                if generation_types is None:
+                    raise ValueError('Expect all sources to have `asins_produced` property, indicating their generation type.')
+                elif len(generation_types) != 1:
+                    raise ValueError('All sources must have only one generation type - multiple not yet supported.')
+                
+                generation_type = generation_types[0]
+                logger.debug(f"Supply for {self._amount} quantity of ASIN {generation_type}.")
+
+                action = {
+                    'type': 'inbound_shipment',
+                    'asin': generation_type,
+                    'origin': node,
+                    'destination': substation,
+                    'quantity': self._amount,
+                    'schedule': current_clock
+                }
+
+                actions.append(action)
+
+        return actions

--- a/src/scse/profiles/national_grid_profile.json
+++ b/src/scse/profiles/national_grid_profile.json
@@ -1,0 +1,12 @@
+{
+  "name": "national_grid_profile",
+  "description": "Environment for simulation of the UK National Grid",
+  "modules": [
+    "scse.modules.selection.national_grid_selection.SourcesSelectionAgent",
+    "scse.modules.topology.national_grid_network.NationalGridNetwork",
+    "scse.modules.customer.national_grid_constant_demand.ConstantDemand",
+    "scse.modules.fulfillment.national_grid_closest_substation_fulfillment.ClosestSubstationFulfillment",
+    "scse.modules.vendor.national_grid_constant_supply.ConstantSupply"
+  ],
+  "metrics": ["scse.metrics.demo_newsvendor_cash_accounting.CashAccounting"]
+}


### PR DESCRIPTION
Very simple starting point for simulating the national grid.

![image](https://user-images.githubusercontent.com/32013626/146021747-61dcd1cc-9f5a-45c5-ab1e-176e3ea92e6a.png)

Methodology:
- Locations have been ignored for now
- A subset of electricity generation methods (gas, solar, and onshore wind) have been modelled as vendors
- A single substation has been created and modelled as a port (could likely be modelled as a warehouse, but wanted a means to differentiate from batteries)
- A single battery has been created and modelled as a warehouse
- A single consumer/customer has been modelled
- At each timestep the consumer requests 10 MW of electricity from the substation
- Further, each of the vendors sends 10 MW of electricity to the substation

Miniscot modifications:
These were kept to an absolute minimum - we should, as far as possible, avoid modifying the core miniscot code. It should be possible to implement 98 % of what we need through custom modules and services.

The below edits are fairly generic and logical extensions of the core miniscot functionality.

- A `half-hourly` time increment was introduced, to align with the BMRS periods
- A `asins_produced` property was added to vendors, rather than assuming that every vendor can provide every ASIN
- An `allow_negative` property was added to ports/warehouses (anything which has the `inventory` property); we want to see when shortfalls occur. This is perhaps bespoke to our use case, although I can imagine others would want to be able to observe such shortfalls.

Necessary steps:
- Miniscot makes heavy reference to `node_types`, or otherwise properties of different types of nodes.
- An enum of allowed types should be introduced, and the core miniscot code updated to use these
- Making this change will increase our understanding of the core miniscot code
- This will in turn make it easier to implement our own node types, better aligned with the problem at hand