### PR TITLE
Placeholder supply and demand services

### DIFF
--- a/src/scse/modules/vendor/national_grid_supply.py
+++ b/src/scse/modules/vendor/national_grid_supply.py
@@ -9,7 +9,7 @@ class ElectricitySupply(Agent):
 
     def __init__(self, run_parameters):
         """
-        Simulates electricity supply.
+        Simulates electricity supply from all sources.
 
         Supply forecast is provided by a service.
         """

--- a/src/scse/profiles/national_grid_profile.json
+++ b/src/scse/profiles/national_grid_profile.json
@@ -4,9 +4,9 @@
   "modules": [
     "scse.modules.selection.national_grid_selection.SourcesSelectionAgent",
     "scse.modules.topology.national_grid_network.NationalGridNetwork",
-    "scse.modules.customer.national_grid_constant_demand.ConstantDemand",
+    "scse.modules.customer.national_grid_demand.ElectricityDemand",
     "scse.modules.fulfillment.national_grid_closest_substation_fulfillment.ClosestSubstationFulfillment",
-    "scse.modules.vendor.national_grid_constant_supply.ConstantSupply"
+    "scse.modules.vendor.national_grid_supply.ElectricitySupply"
   ],
   "metrics": ["scse.metrics.demo_newsvendor_cash_accounting.CashAccounting"]
 }

--- a/src/scse/services/electricity_demand_forecast_service.py
+++ b/src/scse/services/electricity_demand_forecast_service.py
@@ -1,0 +1,30 @@
+import logging
+
+from scse.api.module import Service
+
+logger = logging.getLogger(__name__)
+
+
+class ElectricityDemandForecast(Service):
+    _DEFAULT_AMOUNT = 10
+
+    def __init__(self, run_parameters):
+        """
+        Return the forcasted electricity demand.
+        """
+        logger.debug("Initializing electricity demand forecast service.")
+        self._amount = self._DEFAULT_AMOUNT
+
+    def get_name(self):
+        return "electricity_demand_forecast_service"
+
+    def reset(self, context):
+        logger.debug("Resetting electricity demand forecast service.")
+        pass
+            
+    def get_forecast(self, current_time):
+        # Return the default value
+        # TODO: Replace with trained models/emulators which use current_time
+        demand_amount = self._amount
+
+        return demand_amount

--- a/src/scse/services/electricity_supply_forecast_service.py
+++ b/src/scse/services/electricity_supply_forecast_service.py
@@ -1,0 +1,37 @@
+import logging
+
+from scse.api.module import Service
+
+logger = logging.getLogger(__name__)
+
+
+class ElectricitySupplyForecast(Service):
+    _DEFAULT_AMOUNT = 10
+
+    def __init__(self, run_parameters):
+        """
+        Return the forcasted electricity supply.
+        """
+        logger.debug("Initializing electricity supply forecast service.")
+        self._asin_list = None
+        self._amount = self._DEFAULT_AMOUNT
+
+    def get_name(self):
+        return "electricity_supply_forecast_service"
+
+    def reset(self, context):
+        logger.debug("Resetting electricity supply forecast service.")
+        # So we don't have to reload the data every reset
+        if self._asin_list != context['asin_list']:
+            self._asin_list = context['asin_list']
+            
+    def get_forecast(self, asin, current_time):
+        # Check for data entry errors
+        if asin not in self._asin_list:
+            raise ValueError(f"Electricity supply forecast query failed: {asin} not in asin_list of environment.")
+
+        # Return the default value
+        # TODO: Replace with trained models/emulators which use ASIN and current_time
+        supply_amount = self._amount
+
+        return supply_amount


### PR DESCRIPTION
Created placeholder electricity supply and demand services. These currently provide the same constant values as before, but can be swapped out with either:

- predictions generated from models
- and/or actual data from the BMRS service