### PR TITLE
Electricity as only ASIN

### DIFF
--- a/src/scse/modules/topology/national_grid_network.py
+++ b/src/scse/modules/topology/national_grid_network.py
@@ -32,17 +32,20 @@ class NationalGridNetwork(Env):
         # Added `asins_produced` property
         G.add_node("Solar",
                     node_type = 'vendor',
-                    asins_produced = ['solar'],
+                    # asins_produced = ['solar'],
+                    asins_produced = ['electricity'],
                     location = (-4.216477053445252, 50.7134720325634)
                     )
         G.add_node("Wind Onshore",
                     node_type = 'vendor',
-                    asins_produced = ['wind_onshore'],
+                    # asins_produced = ['wind_onshore'],
+                    asins_produced = ['electricity'],
                     location = (-3.0223770988897174, 57.29950745888362)
                     )
         G.add_node("Fossil Gas",
                     node_type = 'vendor',
-                    asins_produced = ['fossil_gas'],
+                    # asins_produced = ['fossil_gas'],
+                    asins_produced = ['electricity'],
                     location = (-3.4726115079844275, 52.48838509810871)
                     )
 

--- a/src/scse/modules/vendor/national_grid_supply.py
+++ b/src/scse/modules/vendor/national_grid_supply.py
@@ -34,7 +34,7 @@ class ElectricitySupply(Agent):
         # Get a list of substations - remember that these have the type `port` for now
         substations = []
         for node, node_data in G.nodes(data=True):
-            if node_data.get('node_type') == 'port':
+            if node_data.get('node_type') in ['port']:
                 substations.append(node)
         
         if len(substations) == 0:


### PR DESCRIPTION
For now, let the only ASIN be electricity. At some point in the future we may want/need to track the production and consumption of each generation type individually.