### PR TITLE
Rudimentary method of drawing down from battery reserves

### DIFF
--- a/src/scse/main/cli.py
+++ b/src/scse/main/cli.py
@@ -192,7 +192,12 @@ class MiniSCOTDebuggerApp(cmd2.Cmd):
                 nx.draw_networkx_edge_labels(G, pos=pos, ax=ax, edge_labels={k: v}, bbox={'alpha': 0})
 
         # Add a legend
-        plt.legend()
+        ax.legend()
+
+        # Add title showing current clock and time values
+        current_clock = self._state['clock']
+        current_time = self._state['date_time']
+        ax.set_title(f"Clock: {current_clock}; Time: {current_time}")
 
         # Display the plot
         plt.show()

--- a/src/scse/modules/placement/national_grid_battery_drawdown.py
+++ b/src/scse/modules/placement/national_grid_battery_drawdown.py
@@ -1,0 +1,150 @@
+import logging
+import datetime
+
+from scse.api.module import Agent
+from scse.api.network import get_asin_inventory_on_inbound_arcs_to_node
+from scse.services.service_registry import singleton as registry
+
+logger = logging.getLogger(__name__)
+
+
+class BatteryDrawdown(Agent):
+    _DEFAULT_ASIN = 'electricity'
+
+    def __init__(self, run_parameters):
+        """
+        Predicts what the supply deficit at substations will be in the next
+        timestep and attempts to draw from battery reserves to compensate.
+
+        Electricity is sent during the current timestep in the hope to maintain
+        balance at the substation in the next timestep.
+        """
+        self._asin = self._DEFAULT_ASIN
+        self._demand_forecast_service = registry.load_service('electricity_demand_forecast_service', run_parameters)
+        self._supply_forecast_service = registry.load_service('electricity_supply_forecast_service', run_parameters)
+
+    def get_name(self):
+        return 'battery_drawdown'
+
+    def reset(self, context, state):
+        self._asin_list = context['asin_list']
+
+    def compute_actions(self, state):
+        """
+        Determine if there is due to be a supply deficit at any substation, and
+        attempt to meet this with battery reserves.
+        """
+        actions = []
+        current_clock = state['clock']
+        current_time = state['date_time']
+        next_time = current_time + datetime.timedelta(hours=0.5)
+        
+        G = state['network']
+
+        # Get a list of substations - remember that these have the type `port` for now
+        # Determine the forecasted supply deficit for each in the next timestep
+        substations = {}
+        for node, node_data in G.nodes(data=True):
+            if node_data.get('node_type') in ['port']:
+                # Would want to pass the node as an argument to the service, in due time
+                demand_forecast = self._demand_forecast_service.get_forecast(time=next_time)
+
+                # Current capacity will hopefully be close to zero most of the time.
+                # Deviations will occur when supply/demand deviates from what's the forecast,
+                # or when battery capacity falls to zero.
+                current_holding = node_data['inventory'][self._asin]
+
+                # Find all the inbound supply that's on its way
+                inbound_supply = get_asin_inventory_on_inbound_arcs_to_node(G, self._asin, node)
+
+                # Calculate the forecasted deficit
+                substations[node] = demand_forecast - inbound_supply - current_holding
+
+        total_forecasted_deficit = sum(list(substations.values()))
+        logger.debug(f'Total forcasted supply deficit: {total_forecasted_deficit}')
+
+        # If the forecasted supply exceeds demand then nothing needs to be done
+        if total_forecasted_deficit < 0:
+            logger.debug('No action required')
+            return actions
+
+        # Get a list of batteries - remember that these have the type `warehouse` for now
+        # Store current inventory plus any incoming inventory
+        # A substation could currently have an excess of electricity, but a forecasted deficit
+        batteries = {}
+        for node, node_data in G.nodes(data=True):
+            if node_data.get('node_type') in ['warehouse']:
+                inbound_excess = get_asin_inventory_on_inbound_arcs_to_node(G, self._asin, node)
+                batteries[node] = node_data['inventory'][self._asin] + inbound_excess
+
+        available_stored_electricity = sum(list(batteries.values()))
+        logger.debug(f'Capacity currently held in network batteries: {available_stored_electricity}')
+
+        # If all the batteries are empty, nothing can be done
+        if available_stored_electricity == 0:
+            logger.debug('No stored capacity in the network')
+            return actions
+
+        # If the forecasted deficit exceeds the available stored electricity then raise warning
+        # Batteries will be depleted to meet as much of the shortfall as possible
+        if total_forecasted_deficit > available_stored_electricity:
+            logger.debug(f'Not enough stored capacity to meet forecasted full supply shortfall - batteries will be depleted')
+
+        # Perform transfers to drawdown from batteries. Note the requirement to keep track
+        # of battery capacities as they're being drawn down.
+        # Potential future improvements:
+        # - Substations with the greatest predicted deficit are serviced first
+        # - Electricity is drawn down from the closest batteries first
+        for substation in list(substations.keys()):
+            # Starting deficit figure
+            forecasted_deficit = substations[substation]
+            
+            for battery in list(batteries.keys()):
+                # Initial available capacity
+                battery_capacity = batteries[battery]
+
+                # If capacity exceeds the substation's forcasted deficit then fully meet that deficit
+                # Otherwise, drain the battery and remove it from the list
+                if battery_capacity >= forecasted_deficit:
+                    drawdown_amount = forecasted_deficit
+                    batteries[battery] -= forecasted_deficit
+                else:
+                    drawdown_amount = battery_capacity
+                    del batteries[battery]
+                    logger.debug(f"Battery {battery} will be drained.")
+
+                # Update the substation's deficit
+                substations[substation] -= drawdown_amount
+
+                logger.debug(
+                    f"Transferring {drawdown_amount} of ASIN {self._asin} from battery {battery} to substation {substation}."
+                )
+
+                action = {
+                    'type': 'transfer',
+                    'asin': self._asin,
+                    'origin': battery,
+                    'destination': substation,
+                    'quantity': drawdown_amount,
+                    'schedule': current_clock
+                }
+                actions.append(action)
+
+                # If the substation's deficit has now bene met then break
+                if forecasted_deficit == 0:
+                    del substations[substation]
+                    logger.debug(f"Met forecasted supply deficit at substation {substation}.")
+                    break
+
+            # If all batteries have been depleted than break out of loop
+            if len(batteries) == 0:
+                logger.debug("All batteries have been depleted.")
+                break
+        
+        # Report on any forecasted deficit still remaining
+        for substation, remaining_deficit in substations.items():
+            logger.debug(
+                f"Substation {substation} still has a forecasted deficit of {remaining_deficit}"
+            )
+
+        return actions

--- a/src/scse/modules/topology/national_grid_network.py
+++ b/src/scse/modules/topology/national_grid_network.py
@@ -66,7 +66,8 @@ class NationalGridNetwork(Env):
         G.add_node("Battery",
                     node_type = 'warehouse',
                     location = (-1.207637136122046, 51.547526847219395),
-                    inventory = dict.fromkeys(asin_list, self._initial_inventory)
+                    # inventory = dict.fromkeys(asin_list, self._initial_inventory),
+                    inventory = {'electricity': 100}
                     )
 
         # Consumers

--- a/src/scse/profiles/national_grid_profile.json
+++ b/src/scse/profiles/national_grid_profile.json
@@ -7,7 +7,8 @@
     "scse.modules.customer.national_grid_demand.ElectricityDemand",
     "scse.modules.fulfillment.national_grid_closest_substation_fulfillment.ClosestSubstationFulfillment",
     "scse.modules.vendor.national_grid_supply.ElectricitySupply",
-    "scse.modules.placement.national_grid_store_excess_supply.StoreExcessSupply"
+    "scse.modules.placement.national_grid_store_excess_supply.StoreExcessSupply",
+    "scse.modules.placement.national_grid_battery_drawdown.BatteryDrawdown"
   ],
   "metrics": ["scse.metrics.demo_newsvendor_cash_accounting.CashAccounting"]
 }

--- a/src/scse/services/electricity_demand_forecast_service.py
+++ b/src/scse/services/electricity_demand_forecast_service.py
@@ -22,9 +22,9 @@ class ElectricityDemandForecast(Service):
         logger.debug("Resetting electricity demand forecast service.")
         pass
             
-    def get_forecast(self, current_time):
+    def get_forecast(self, time):
         # Return the default value
-        # TODO: Replace with trained models/emulators which use current_time
+        # TODO: Replace with trained models/emulators which use time
         demand_amount = self._amount
 
         return demand_amount

--- a/src/scse/services/electricity_demand_forecast_service.py
+++ b/src/scse/services/electricity_demand_forecast_service.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 
 
 class ElectricityDemandForecast(Service):
-    _DEFAULT_AMOUNT = 10
+    _DEFAULT_AMOUNT = 40
 
     def __init__(self, run_parameters):
         """

--- a/src/scse/services/electricity_supply_forecast_service.py
+++ b/src/scse/services/electricity_supply_forecast_service.py
@@ -25,13 +25,13 @@ class ElectricitySupplyForecast(Service):
         if self._asin_list != context['asin_list']:
             self._asin_list = context['asin_list']
             
-    def get_forecast(self, asin, current_time):
+    def get_forecast(self, asin, time):
         # Check for data entry errors
         if asin not in self._asin_list:
             raise ValueError(f"Electricity supply forecast query failed: {asin} not in asin_list of environment.")
 
         # Return the default value
-        # TODO: Replace with trained models/emulators which use ASIN and current_time
+        # TODO: Replace with trained models/emulators which use ASIN and time
         supply_amount = self._amount
 
         return supply_amount


### PR DESCRIPTION
At the end of each run, the network tries to predict what the supply deficit will be in the next timestep. If battery reserves are available within the network, it will transfer these to any substation with a predicted shortfall.

Using the picture below to explain the process:
- the battery started with a capacity of 50 MW
- the customer draws 40 MW during each period, and all vendors produce 10 MW. This is currently time invariant.
- the substation is balanced in the current timestep (it has 0 MW); we forecast/know that in the next timestep it will be sent 30 MW and have 40 MW drawn from it
- Therefore, it would have a deficit of 10 MW
- Thus, 10 MW has been drawn from the battery - hence it is showing 40 MW, with 10 MW on its way to the substation

![image](https://user-images.githubusercontent.com/32013626/146206161-ff4939b2-a714-42e9-b079-bcfaf862d8c1.png)