### PR TITLE
Introduce warehouse capacities

### DIFF
--- a/src/scse/api/network.py
+++ b/src/scse/api/network.py
@@ -50,6 +50,8 @@ def get_asin_inventory_on_inbound_arcs_to_node_by_arrival_time(
 def get_asin_inventory_in_node(node_data, asin):
     return node_data.get('inventory', {}).get(asin, 0)
 
+def get_asin_max_inventory_in_node(node_data, asin):
+    return node_data.get('max_inventory', {}).get(asin, 0)
 
 def set_asin_inventory_in_node(node_data, asin, quantity):
     node_data.get('inventory', {})[asin] = quantity

--- a/src/scse/api/network.py
+++ b/src/scse/api/network.py
@@ -51,7 +51,8 @@ def get_asin_inventory_in_node(node_data, asin):
     return node_data.get('inventory', {}).get(asin, 0)
 
 def get_asin_max_inventory_in_node(node_data, asin):
-    return node_data.get('max_inventory', {}).get(asin, 0)
+    # Default assumption is that nodes have effectively infinite capacity
+    return node_data.get('max_inventory', {}).get(asin, 10e10)
 
 def set_asin_inventory_in_node(node_data, asin, quantity):
     node_data.get('inventory', {})[asin] = quantity

--- a/src/scse/main/cli.py
+++ b/src/scse/main/cli.py
@@ -162,6 +162,8 @@ class MiniSCOTDebuggerApp(cmd2.Cmd):
             onhand += sum(node_details.get('inventory', {None: 0}).values())
             onhand += node_details.get('delivered', 0)
 
+            # Very rudimentary way of determining a node is over capacity
+            # Could be that it is over capacity for one ASIN, but below capacity for all the others
             text_col = 'k'
             if onhand < 0 or onhand >= sum(node_details.get('max_inventory', {None: 10e10}).values()):
                 text_col = 'r'

--- a/src/scse/main/cli.py
+++ b/src/scse/main/cli.py
@@ -149,25 +149,35 @@ class MiniSCOTDebuggerApp(cmd2.Cmd):
         G = self._state['network']
         pos = {node_name: node_data['location'] for node_name, node_data in G.nodes(data=True)}
 
-        # Create a dictionary of nodes by type, and of total holdings at each node
+        # Plot the nodes and node labels
+        # Each node type has its own color
+        # Nodes with negative capacity or capacity >= the max have red label
         node_type_dict = defaultdict(list)
-        node_inventory_quantity_dict = defaultdict(int)
         for node_name, node_details in G.nodes.items():
+            # This will be used when plotting the nodes
             node_type_dict[node_details['node_type']].append(node_name)
 
-            node_inventory_quantity_dict[node_name] += sum(node_details.get('inventory', {None: 0}).values())
-            node_inventory_quantity_dict[node_name] += node_details.get('delivered', 0)
+            # Determine the total inventory onhand
+            onhand = 0
+            onhand += sum(node_details.get('inventory', {None: 0}).values())
+            onhand += node_details.get('delivered', 0)
+
+            text_col = 'k'
+            if onhand < 0 or onhand >= sum(node_details.get('max_inventory', {None: 10e10}).values()):
+                text_col = 'r'
+
+            # Add label with quantity of product held
+            nx.draw_networkx_labels(G, pos=pos, ax=ax, labels={node_name: onhand}, font_color=text_col, clip_on=False)            
 
         # Plot the nodes, with a different colour for each type
         color_cycle = cycle(['#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd'])
         for node_type, node_names in node_type_dict.items():
             nx.draw_networkx_nodes(G, pos=pos, ax=ax, nodelist=node_names, node_color=next(color_cycle), label=node_type)
 
-        # Add two sets of node labels - name and quantity of product held
+        # Add node names as labels
         shifted_pos = {k:[v[0],v[1]+.35] for k, v in pos.items()}
         nx.draw_networkx_labels(G, shifted_pos, clip_on=False)
-        nx.draw_networkx_labels(G, pos=pos, ax=ax, labels=node_inventory_quantity_dict, clip_on=False)
-        
+
         # Identify uni and bidirectional edges; record the total quantity of product in transit along each edge
         unidirectional_edges = {}
         bidirectional_edges = {}
@@ -204,9 +214,6 @@ class MiniSCOTDebuggerApp(cmd2.Cmd):
                 nx.draw_networkx_edge_labels(G, pos=pos, ax=ax, edge_labels={k: f'{v}/{bidirectional_edges[(edge_end, edge_start)]}'}, bbox={'alpha': 0})
             elif v != 0:
                 nx.draw_networkx_edge_labels(G, pos=pos, ax=ax, edge_labels={k: v}, bbox={'alpha': 0})
-
-        # Add a legend
-        ax.legend()
 
         # Add title showing current clock and time values
         current_clock = self._state['clock']

--- a/src/scse/modules/placement/national_grid_store_excess_supply.py
+++ b/src/scse/modules/placement/national_grid_store_excess_supply.py
@@ -2,7 +2,9 @@ import logging
 import math
 
 from scse.api.module import Agent
-from scse.api.network import get_asin_inventory_in_node
+from scse.api.network import (
+    get_asin_inventory_in_node, get_asin_max_inventory_in_node
+)
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +41,10 @@ class StoreExcessSupply(Agent):
         batteries = []
         for node, node_data in G.nodes(data=True):
             if node_data.get('node_type') in ['warehouse']:
-                batteries.append((node, node_data))
+                # Need to keep track of what excess capacity is already being sent
+                module_copy = node_data.copy()
+                module_copy['incoming'] = 0
+                batteries.append((node, module_copy))
 
         # Get a list of substations - remember that these have the type `port` for now
         # Could have put below logic here; kept separation for readability
@@ -50,26 +55,55 @@ class StoreExcessSupply(Agent):
 
         # Go through the substations and identify any excess they currently have
         # Share the excess evenly across the battery network
+        # Potential future improvements:
+        # - Each battery fully filled until excess capacity is gone; could do more evenly
+        # - Fill closer batteries first
         for substation, substation_data in substations:
             onhand = get_asin_inventory_in_node(substation_data, self._asin)
 
             if onhand > 0:
-                logger.debug(f"Storing excess of {onhand} ASIN {self._asin} from substation {substation}.")
+                logger.debug(
+                    f"Attempting to store excess of {onhand} ASIN {self._asin} from substation {substation}."
+                    )
 
+                # Loop through batteries in the network - fill until excess is used, or batteries full
                 for battery, battery_data in batteries:
-                    # Note: Whole number of MW being transmitted
-                    # Have not yet removed miniscot check preventing float
+                    current_inventory = get_asin_inventory_in_node(battery_data, self._asin)
+                    max_inventory = get_asin_max_inventory_in_node(battery_data, self._asin)
+                    available_capacity = max_inventory - current_inventory - battery_data['incoming']
+
+                    if available_capacity == 0:
+                        logger.debug(f'Battery {battery} is already full')
+                        continue
+                    if available_capacity >= onhand:
+                        transfer_amount = onhand
+                    else:
+                        logger.debug(f'Battery {battery} is going to be filled')
+                        transfer_amount = available_capacity
+
+                    onhand -= transfer_amount
+                    battery_data['incoming'] += transfer_amount
+
+                    logger.debug(
+                        f"Transferring {transfer_amount} of ASIN {self._asin} from substation {substation} to battery {battery}."
+                    )
+
                     action = {
                         'type': 'transfer',
                         'asin': self._asin,
-                        'quantity': math.floor(onhand/len(batteries)),
+                        'quantity': transfer_amount,
                         'schedule': state['clock'],
                         'origin': substation,
                         'destination': battery
                     }
                     actions.append(action)
 
+            if onhand > 0:
+                logger.debug(
+                    f"Excess of {onhand} ASIN {self._asin} will remain at substation {substation}."
+                )
+
         if len(actions) == 0:
-            logger.debug("No action was required")
+            logger.debug("No actions taken")
 
         return actions

--- a/src/scse/modules/placement/national_grid_store_excess_supply.py
+++ b/src/scse/modules/placement/national_grid_store_excess_supply.py
@@ -75,12 +75,8 @@ class StoreExcessSupply(Agent):
                     if available_capacity == 0:
                         logger.debug(f'Battery {battery} is already full')
                         continue
-                    if available_capacity >= onhand:
-                        transfer_amount = onhand
-                    else:
-                        logger.debug(f'Battery {battery} is going to be filled')
-                        transfer_amount = available_capacity
 
+                    transfer_amount = min(onhand, available_capacity)
                     onhand -= transfer_amount
                     battery_data['incoming'] += transfer_amount
 

--- a/src/scse/modules/topology/national_grid_network.py
+++ b/src/scse/modules/topology/national_grid_network.py
@@ -67,7 +67,8 @@ class NationalGridNetwork(Env):
                     node_type = 'warehouse',
                     location = (-1.207637136122046, 51.547526847219395),
                     # inventory = dict.fromkeys(asin_list, self._initial_inventory),
-                    inventory = {'electricity': 100}
+                    inventory = {'electricity': 100},
+                    max_inventory = {'electricity': 200}
                     )
 
         # Consumers


### PR DESCRIPTION
Introducing the concept of maximum warehouse inventory. This is then being used when looking to transfer excess capacity from substations to batteries - batteries can only be filled to their maximum capacity. Update the visualisation to turn labels red when either a node:
- has negative inventory
- has inventory exceeding its maximum

![image](https://user-images.githubusercontent.com/32013626/146372021-5617ca00-7510-4113-9502-764b2587487b.png)