### PR TITLE
Supply forecast service receives energy generation type

### DIFF
--- a/src/scse/constants/national_grid_constants.py
+++ b/src/scse/constants/national_grid_constants.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+ELECTRICITY_ASIN: str = 'electricity'
+
+@dataclass
+class _EnergyGenerationAsins:
+    solar: str = 'Solar'
+    fossil_gas: str = 'Fossil Gas'
+    wind_onshore: str = 'Wind Onshore'
+ENERGY_GENERATION_ASINS = _EnergyGenerationAsins()

--- a/src/scse/modules/customer/national_grid_demand.py
+++ b/src/scse/modules/customer/national_grid_demand.py
@@ -2,12 +2,13 @@ import logging
 
 from scse.api.module import Agent
 from scse.services.service_registry import singleton as registry
+from scse.constants.national_grid_constants import ELECTRICITY_ASIN
 
 logger = logging.getLogger(__name__)
 
 
 class ElectricityDemand(Agent):
-    _DEFAULT_ASIN = 'electricity'
+    _DEFAULT_ASIN = ELECTRICITY_ASIN
     _DEFAULT_CUSTOMER = 'Consumers'
 
     def __init__(self, run_parameters):

--- a/src/scse/modules/placement/national_grid_store_excess_supply.py
+++ b/src/scse/modules/placement/national_grid_store_excess_supply.py
@@ -5,12 +5,13 @@ from scse.api.module import Agent
 from scse.api.network import (
     get_asin_inventory_in_node, get_asin_max_inventory_in_node
 )
+from scse.constants.national_grid_constants import ELECTRICITY_ASIN
 
 logger = logging.getLogger(__name__)
 
 
 class StoreExcessSupply(Agent):
-    _DEFAULT_ASIN = 'electricity'
+    _DEFAULT_ASIN = ELECTRICITY_ASIN
 
     def __init__(self, run_parameters):
         """

--- a/src/scse/modules/selection/national_grid_selection.py
+++ b/src/scse/modules/selection/national_grid_selection.py
@@ -1,6 +1,7 @@
 import logging
 
 from scse.api.module import Env
+from scse.constants.national_grid_constants import ELECTRICITY_ASIN, ENERGY_GENERATION_ASINS
 
 logger = logging.getLogger(__name__)
 
@@ -22,9 +23,9 @@ class SourcesSelectionAgent(Env):
             if self._asin_selection == 0:
                 # Default to return all supported electricity source types
                 asin_list = [
-                    "solar",
-                    "wind_onshore",
-                    "fossil_gas",
+                    ENERGY_GENERATION_ASINS.solar,
+                    ENERGY_GENERATION_ASINS.wind_onshore,
+                    ENERGY_GENERATION_ASINS.fossil_gas
                 ]
             else:
                 raise ValueError("""
@@ -37,9 +38,9 @@ class SourcesSelectionAgent(Env):
             asin_selection run parameter.
             """)
 
-        # Add generic "electricity" to list
+        # Add generic `electricity` to list
         # This is what substations (aka ports) and batteries (aka warehouses) deal in
-        asin_list.append("electricity")
+        asin_list.append(ELECTRICITY_ASIN)
 
         logger.debug(f"Electricity sources selected = {asin_list}.")
         return asin_list

--- a/src/scse/modules/topology/national_grid_network.py
+++ b/src/scse/modules/topology/national_grid_network.py
@@ -1,5 +1,7 @@
 import networkx as nx
+
 from scse.api.module import Env
+from scse.constants.national_grid_constants import ELECTRICITY_ASIN, ENERGY_GENERATION_ASINS
 
 
 class NationalGridNetwork(Env):
@@ -32,20 +34,17 @@ class NationalGridNetwork(Env):
         # Added `asins_produced` property
         G.add_node("Solar",
                     node_type = 'vendor',
-                    # asins_produced = ['solar'],
-                    asins_produced = ['electricity'],
+                    asins_produced = [ENERGY_GENERATION_ASINS.solar],
                     location = (-4.216477053445252, 50.7134720325634)
                     )
         G.add_node("Wind Onshore",
                     node_type = 'vendor',
-                    # asins_produced = ['wind_onshore'],
-                    asins_produced = ['electricity'],
+                    asins_produced = [ENERGY_GENERATION_ASINS.wind_onshore],
                     location = (-3.0223770988897174, 57.29950745888362)
                     )
         G.add_node("Fossil Gas",
                     node_type = 'vendor',
-                    # asins_produced = ['fossil_gas'],
-                    asins_produced = ['electricity'],
+                    asins_produced = [ENERGY_GENERATION_ASINS.fossil_gas],
                     location = (-3.4726115079844275, 52.48838509810871)
                     )
 
@@ -67,8 +66,8 @@ class NationalGridNetwork(Env):
                     node_type = 'warehouse',
                     location = (-1.207637136122046, 51.547526847219395),
                     # inventory = dict.fromkeys(asin_list, self._initial_inventory),
-                    inventory = {'electricity': 100},
-                    max_inventory = {'electricity': 200}
+                    inventory = {ELECTRICITY_ASIN: 100},
+                    max_inventory = {ELECTRICITY_ASIN: 200}
                     )
 
         # Consumers

--- a/src/scse/modules/vendor/national_grid_supply.py
+++ b/src/scse/modules/vendor/national_grid_supply.py
@@ -1,11 +1,14 @@
+import logging
+
 from scse.api.module import Agent
 from scse.services.service_registry import singleton as registry
+from scse.constants.national_grid_constants import ELECTRICITY_ASIN, ENERGY_GENERATION_ASINS
 
-import logging
 logger = logging.getLogger(__name__)
 
 
 class ElectricitySupply(Agent):
+    _DEFAULT_SUPPLY_ASIN = ELECTRICITY_ASIN
 
     def __init__(self, run_parameters):
         """
@@ -13,6 +16,7 @@ class ElectricitySupply(Agent):
 
         Supply forecast is provided by a service.
         """
+        self._supply_asin = self._DEFAULT_SUPPLY_ASIN
         self._supply_forecast_service = registry.load_service('electricity_supply_forecast_service', run_parameters)
 
     def get_name(self):
@@ -59,9 +63,10 @@ class ElectricitySupply(Agent):
                 
                 logger.debug(f"Supply for {forecasted_supply} quantity of ASIN {generation_type}.")
 
+                # Note: The default ASIN is sent (i.e. electricity), regardless of generation type
                 action = {
                     'type': 'inbound_shipment',
-                    'asin': generation_type,
+                    'asin': self._supply_asin,
                     'origin': node,
                     'destination': substation,
                     'quantity': forecasted_supply,

--- a/src/scse/services/electricity_supply_forecast_service.py
+++ b/src/scse/services/electricity_supply_forecast_service.py
@@ -27,6 +27,8 @@ class ElectricitySupplyForecast(Service):
             
     def get_forecast(self, asin, time):
         """
+        Generate a supply forcast for the given ASIN/electricity generation type.
+
         NOTE: Given a time, the forecast must be deterministic.
         i.e. the same forecast is returned when the same arguments
         are passed.

--- a/src/scse/services/electricity_supply_forecast_service.py
+++ b/src/scse/services/electricity_supply_forecast_service.py
@@ -1,6 +1,7 @@
 import logging
 
 from scse.api.module import Service
+from scse.constants.national_grid_constants import ENERGY_GENERATION_ASINS
 
 logger = logging.getLogger(__name__)
 
@@ -27,19 +28,22 @@ class ElectricitySupplyForecast(Service):
             
     def get_forecast(self, asin, time):
         """
-        Generate a supply forcast for the given ASIN/electricity generation type.
+        Generate a supply forcast for the given ASIN/electricity generation type,
+        and the given time.
 
         NOTE: Given a time, the forecast must be deterministic.
         i.e. the same forecast is returned when the same arguments
         are passed.
         """
 
-        # Check for data entry errors
-        if asin not in self._asin_list:
-            raise ValueError(f"Electricity supply forecast query failed: {asin} not in asin_list of environment.")
-
-        # Return the default value
-        # TODO: Replace with trained models/emulators which use ASIN and time
-        supply_amount = self._amount
-
-        return supply_amount
+        if asin == ENERGY_GENERATION_ASINS.solar:
+            if time.hour <= 8 or time.hour >= 18:
+                return 0
+            else:
+                return self._amount
+        elif asin == ENERGY_GENERATION_ASINS.wind_onshore:
+            return self._amount * 2
+        elif asin == ENERGY_GENERATION_ASINS.fossil_gas:
+            return self._amount * 3
+        else:
+            raise ValueError(f"Electricity supply forecast query failed: {asin} not recognised.")


### PR DESCRIPTION
Ensure that the supply forecast service receives the type of electricity as an argument, so that it can generate an appropriate forecast.

For example, in this PR, solar energy is only produced between 0900-1800.