### PR TITLE
Use MWh as units throughout

### DIFF
--- a/src/scse/constants/national_grid_constants.py
+++ b/src/scse/constants/national_grid_constants.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 
+PERIOD_LENGTH_HOURS = 0.5
+
 ELECTRICITY_ASIN: str = 'electricity'
 
 @dataclass

--- a/src/scse/modules/placement/national_grid_battery_drawdown.py
+++ b/src/scse/modules/placement/national_grid_battery_drawdown.py
@@ -4,12 +4,15 @@ import datetime
 from scse.api.module import Agent
 from scse.api.network import get_asin_inventory_on_inbound_arcs_to_node
 from scse.services.service_registry import singleton as registry
+from scse.constants.national_grid_constants import (
+    ELECTRICITY_ASIN, PERIOD_LENGTH_HOURS
+)
 
 logger = logging.getLogger(__name__)
 
 
 class BatteryDrawdown(Agent):
-    _DEFAULT_ASIN = 'electricity'
+    _DEFAULT_ASIN = ELECTRICITY_ASIN
 
     def __init__(self, run_parameters):
         """
@@ -38,7 +41,7 @@ class BatteryDrawdown(Agent):
         actions = []
         current_clock = state['clock']
         current_time = state['date_time']
-        next_time = current_time + datetime.timedelta(hours=0.5)
+        next_time = current_time + datetime.timedelta(hours=PERIOD_LENGTH_HOURS)
         
         G = state['network']
 

--- a/src/scse/services/electricity_demand_forecast_service.py
+++ b/src/scse/services/electricity_demand_forecast_service.py
@@ -1,6 +1,7 @@
 import logging
 
 from scse.api.module import Service
+from scse.constants.national_grid_constants import PERIOD_LENGTH_HOURS
 
 logger = logging.getLogger(__name__)
 
@@ -10,7 +11,7 @@ class ElectricityDemandForecast(Service):
 
     def __init__(self, run_parameters):
         """
-        Return the forcasted electricity demand.
+        Return the forcasted electricity demand, in MWh.
         """
         logger.debug("Initializing electricity demand forecast service.")
         self._amount = self._DEFAULT_AMOUNT
@@ -24,6 +25,11 @@ class ElectricityDemandForecast(Service):
             
     def get_forecast(self, time):
         """
+        Generate a demand forcast for the given time.
+
+        NOTE: Forecast must be in MWh. Use PERIOD_LENGTH_HOURS as the
+        conversion factor from MW.
+
         NOTE: Given a time, the forecast must be deterministic.
         i.e. the same forecast is returned when the same arguments
         are passed.
@@ -31,6 +37,8 @@ class ElectricityDemandForecast(Service):
 
         # Return the default value
         # TODO: Replace with trained models/emulators which use time
-        demand_amount = self._amount
+        demand_amount = int(
+            (self._amount * int((time.hour*2) + (time.minute/30) + 1)) * PERIOD_LENGTH_HOURS
+        )
 
         return demand_amount

--- a/src/scse/services/electricity_supply_forecast_service.py
+++ b/src/scse/services/electricity_supply_forecast_service.py
@@ -1,7 +1,9 @@
 import logging
 
 from scse.api.module import Service
-from scse.constants.national_grid_constants import ENERGY_GENERATION_ASINS
+from scse.constants.national_grid_constants import (
+    ENERGY_GENERATION_ASINS, PERIOD_LENGTH_HOURS
+)
 
 logger = logging.getLogger(__name__)
 
@@ -11,7 +13,7 @@ class ElectricitySupplyForecast(Service):
 
     def __init__(self, run_parameters):
         """
-        Return the forcasted electricity supply.
+        Return the forcasted electricity supply, in MWh.
         """
         logger.debug("Initializing electricity supply forecast service.")
         self._asin_list = None
@@ -28,8 +30,11 @@ class ElectricitySupplyForecast(Service):
             
     def get_forecast(self, asin, time):
         """
-        Generate a supply forcast for the given ASIN/electricity generation type,
-        and the given time.
+        Generate a supply forcast for the given ASIN/electricity generation
+        type, and the given time.
+
+        NOTE: Forecast must be in MWh. Use PERIOD_LENGTH_HOURS as the
+        conversion factor from MW.
 
         NOTE: Given a time, the forecast must be deterministic.
         i.e. the same forecast is returned when the same arguments
@@ -40,10 +45,10 @@ class ElectricitySupplyForecast(Service):
             if time.hour <= 8 or time.hour >= 18:
                 return 0
             else:
-                return self._amount
+                return int(self._amount * PERIOD_LENGTH_HOURS)
         elif asin == ENERGY_GENERATION_ASINS.wind_onshore:
-            return self._amount * 2
+            return int(self._amount * 2 * PERIOD_LENGTH_HOURS)
         elif asin == ENERGY_GENERATION_ASINS.fossil_gas:
-            return self._amount * 3
+            return int(self._amount * 3 * PERIOD_LENGTH_HOURS)
         else:
             raise ValueError(f"Electricity supply forecast query failed: {asin} not recognised.")


### PR DESCRIPTION
Ensure that the units used throughout the simulation are MWh, rather than MW.