### PR TITLE
Centralising default run parameter specification

### DIFF
--- a/src/scse/api/simulation.py
+++ b/src/scse/api/simulation.py
@@ -1,24 +1,17 @@
 from scse.main.notebook_interface import miniSCOTnotebook
+from scse.default_run_parameters.national_grid_default_run_parameters import DEFAULT_RUN_PARAMETERS
+
 import logging
 
-DEFAULT_LOGGING_LEVEL = 'CRITICAL'
-DEFAULT_START_DATE = '2019-01-01'
-DEFAULT_TIME_INCREMENT = 'half-hourly'
-DEFAULT_HORIZON = 100
-DEFAULT_SIMULATION_SEED = 12345
-DEFAULT_NUM_BATTERIES = 1
-DEFAULT_MAX_BATTERY_CAPACITY = 50
-DEFAULT_BATTERY_PENALTY = 500
 
-
-def run_simulation(logging_level=DEFAULT_LOGGING_LEVEL,
-                   simulation_seed=DEFAULT_SIMULATION_SEED,
-                   start_date=DEFAULT_START_DATE,
-                   time_increment=DEFAULT_TIME_INCREMENT,
-                   time_horizon=DEFAULT_HORIZON,
-                   num_batteries=DEFAULT_NUM_BATTERIES,
-                   max_battery_capacity=DEFAULT_MAX_BATTERY_CAPACITY,
-                   battery_penalty=DEFAULT_BATTERY_PENALTY):
+def run_simulation(logging_level=DEFAULT_RUN_PARAMETERS.logging_level,
+                   simulation_seed=DEFAULT_RUN_PARAMETERS.simulation_seed,
+                   start_date=DEFAULT_RUN_PARAMETERS.start_date,
+                   time_increment=DEFAULT_RUN_PARAMETERS.time_increment,
+                   time_horizon=DEFAULT_RUN_PARAMETERS.time_horizon,
+                   num_batteries=DEFAULT_RUN_PARAMETERS.num_batteries,
+                   max_battery_capacity=DEFAULT_RUN_PARAMETERS.max_battery_capacity,
+                   battery_penalty=DEFAULT_RUN_PARAMETERS.battery_penalty):
 
     logger = logging.getLogger()
     if logging_level == 'DEBUG':

--- a/src/scse/api/simulation.py
+++ b/src/scse/api/simulation.py
@@ -4,7 +4,7 @@ from scse.default_run_parameters.national_grid_default_run_parameters import DEF
 import logging
 
 
-def run_simulation(logging_level=DEFAULT_RUN_PARAMETERS.logging_level,
+def run_simulation(logging_level='CRITICAL',
                    simulation_seed=DEFAULT_RUN_PARAMETERS.simulation_seed,
                    start_date=DEFAULT_RUN_PARAMETERS.start_date,
                    time_increment=DEFAULT_RUN_PARAMETERS.time_increment,

--- a/src/scse/api/simulation.py
+++ b/src/scse/api/simulation.py
@@ -4,7 +4,7 @@ from scse.default_run_parameters.national_grid_default_run_parameters import DEF
 import logging
 
 
-def run_simulation(logging_level='CRITICAL',
+def run_simulation(logging_level=DEFAULT_RUN_PARAMETERS.simulation_logging_level,
                    simulation_seed=DEFAULT_RUN_PARAMETERS.simulation_seed,
                    start_date=DEFAULT_RUN_PARAMETERS.start_date,
                    time_increment=DEFAULT_RUN_PARAMETERS.time_increment,

--- a/src/scse/controller/miniscot.py
+++ b/src/scse/controller/miniscot.py
@@ -17,6 +17,9 @@ from scse.profiles.profile import load_profile, instantiate_class
 from scse.constants.national_grid_constants import (
     ELECTRICITY_ASIN
 )
+from scse.default_run_parameters.national_grid_default_run_parameters import (
+    DEFAULT_RUN_PARAMETERS
+)
 
 # TODO Right now, let's log all by setting DEBUG at the root level...
 # Later remove and let it be configured.
@@ -32,15 +35,15 @@ class SupplyChainEnvironment:
     #  'run parameters' to be specified directly in the profiles.
     # The trade-off is that profile values are not meant to change (per run).
     def __init__(self,
-                 profile='national_grid_profile.json',       # defines the set of modules to use
-                 simulation_seed=12345,   # controls randomness throughout simulation
-                 start_date='2019-01-01',  # simulation start date
-                 time_increment='daily',  # timestep increment
-                 time_horizon=100,        # timestep horizon
-                 asin_selection=1,
-                 num_batteries=10,
-                 max_battery_capacity=50,  # how many / which asins to simulate
-                 battery_penalty=500):
+                 profile=DEFAULT_RUN_PARAMETERS.run_profile,       # defines the set of modules to use
+                 simulation_seed=DEFAULT_RUN_PARAMETERS.simulation_seed,   # controls randomness throughout simulation
+                 start_date=DEFAULT_RUN_PARAMETERS.start_date,  # simulation start date
+                 time_increment=DEFAULT_RUN_PARAMETERS.time_increment,  # timestep increment
+                 time_horizon=DEFAULT_RUN_PARAMETERS.time_horizon,        # timestep horizon
+                 asin_selection=DEFAULT_RUN_PARAMETERS.asin_selection,  # how many / which asins to simulate
+                 num_batteries=DEFAULT_RUN_PARAMETERS.num_batteries,
+                 max_battery_capacity=DEFAULT_RUN_PARAMETERS.max_battery_capacity,  
+                 battery_penalty=DEFAULT_RUN_PARAMETERS.battery_penalty):
 
         self._program_start_time = time.time()
         self._miniscot_time_profile = {}

--- a/src/scse/default_run_parameters/core_default_run_parameters.py
+++ b/src/scse/default_run_parameters/core_default_run_parameters.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+@dataclass
+class CoreRunParameters:
+    run_profile = ''
+    asin_selection = 1
+    logging_level = 'DEBUG'
+    start_date = '2019-01-01'
+    time_increment = 'daily'
+    time_horizon = 100
+    simulation_seed = 12345
+CORE_DEFAULT_RUN_PARAMETERS = CoreRunParameters()

--- a/src/scse/default_run_parameters/national_grid_default_run_parameters.py
+++ b/src/scse/default_run_parameters/national_grid_default_run_parameters.py
@@ -11,6 +11,7 @@ class _RunParameters(CoreRunParameters):
     time_increment = 'half-hourly'
 
     # Bespoke parameters
+    simulation_logging_level = 'CRITICAL'
     num_batteries = 1
     max_battery_capacity = 50
     battery_penalty = 500

--- a/src/scse/default_run_parameters/national_grid_default_run_parameters.py
+++ b/src/scse/default_run_parameters/national_grid_default_run_parameters.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+
+from scse.default_run_parameters.core_default_run_parameters import CoreRunParameters
+
+@dataclass
+class _RunParameters(CoreRunParameters):
+    # Override certain core parameters
+    run_profile = 'national_grid_profile.json'
+    asin_selection = 0  # Use 0 for national grid simulation
+    logging_level = 'DEBUG'  # May need to set to critical occassionally
+    time_increment = 'half-hourly'
+
+    # Bespoke parameters
+    num_batteries = 1
+    max_battery_capacity = 50
+    battery_penalty = 500
+DEFAULT_RUN_PARAMETERS = _RunParameters()

--- a/src/scse/main/cli.py
+++ b/src/scse/main/cli.py
@@ -8,7 +8,9 @@ import networkx as nx
 from itertools import cycle
 from collections import defaultdict
 import matplotlib.pyplot as plt
+
 from scse.controller import miniscot as miniSCOT
+from scse.default_run_parameters.national_grid_default_run_parameters import DEFAULT_RUN_PARAMETERS
 
 
 class MiniSCOTDebuggerApp(cmd2.Cmd):
@@ -18,9 +20,6 @@ class MiniSCOTDebuggerApp(cmd2.Cmd):
     _DEFAULT_SIMULATION_SEED = 12345
     _DEFAULT_ASIN_SELECTION = 0  # or use an integer value to select the number of asins
     _DEFAULT_PROFILE = 'national_grid_profile'
-    _DEFAULT_NUM_BATTERIES = 10
-    _DEFAULT_MAX_BATTERY_CAPACITY = 50
-    _DEFAULT_BATTERY_PENALTY = 500
 
     def __init__(self, **args):
         super().__init__(args)
@@ -35,9 +34,9 @@ class MiniSCOTDebuggerApp(cmd2.Cmd):
                     time_horizon=self._DEFAULT_HORIZON,
                     asin_selection=self._DEFAULT_ASIN_SELECTION,
                     profile=self._DEFAULT_PROFILE,
-                    num_batteries=self._DEFAULT_NUM_BATTERIES,
-                    max_battery_capacity=self._DEFAULT_MAX_BATTERY_CAPACITY,
-                    battery_penalty=self._DEFAULT_BATTERY_PENALTY)
+                    num_batteries=DEFAULT_RUN_PARAMETERS.num_batteries,
+                    max_battery_capacity=DEFAULT_RUN_PARAMETERS.max_battery_capacity,
+                    battery_penalty=DEFAULT_RUN_PARAMETERS.battery_penalty)
 
         self._set_prompt()
 
@@ -61,8 +60,6 @@ class MiniSCOTDebuggerApp(cmd2.Cmd):
         self._env.reset_agents(self._context, self._state)
 
     param_parser = argparse.ArgumentParser()
-    param_parser.add_argument('--max_battery_capacity', help="max battery capacity (default 50)",
-                              type=int, default=_DEFAULT_MAX_BATTERY_CAPACITY)
     param_parser.add_argument(
         '--start_date', help="simulation will at date 'yyyy-mm-dd' (default 2019-01-01)", type=str, default=_DEFAULT_START_DATE)
     param_parser.add_argument(
@@ -76,9 +73,19 @@ class MiniSCOTDebuggerApp(cmd2.Cmd):
     param_parser.add_argument(
         '--profile', help="profile (default minimal)", type=str, default=_DEFAULT_PROFILE)
     param_parser.add_argument(
-        '--num_batteries', help="number of batteries (default 10)", type=int, default=_DEFAULT_NUM_BATTERIES)
+        '--num_batteries',
+        help=f"number of batteries (default {DEFAULT_RUN_PARAMETERS.num_batteries})",
+        type=int, default=DEFAULT_RUN_PARAMETERS.num_batteries)
     param_parser.add_argument(
-        '--battery_penalty', help=f"penalty for the addition of a new battery (default {_DEFAULT_BATTERY_PENALTY})", type=int, default=_DEFAULT_BATTERY_PENALTY)
+        '--max_battery_capacity',
+        help=f"max battery capacity (default {DEFAULT_RUN_PARAMETERS.max_battery_capacity})",
+        type=int, default=DEFAULT_RUN_PARAMETERS.max_battery_capacity)
+    param_parser.add_argument(
+        '--battery_penalty',
+        help=(
+            f"penalty for the addition of a new battery (default {DEFAULT_RUN_PARAMETERS.battery_penalty})"
+        ),
+        type=int, default=DEFAULT_RUN_PARAMETERS.battery_penalty)
     #param_parser.add_argument('-asin', help="list of ASINs.", action='append', default=_DEFAULT_ASIN_LIST)
 
     @cmd2.with_argparser(param_parser)

--- a/src/scse/main/notebook_interface.py
+++ b/src/scse/main/notebook_interface.py
@@ -1,25 +1,23 @@
 from scse.controller import miniscot as miniSCOT
+from scse.default_run_parameters.national_grid_default_run_parameters import DEFAULT_RUN_PARAMETERS
 
 
 class miniSCOTnotebook():
-    DEFAULT_START_DATE = '2019-01-01'
-    DEFAULT_TIME_INCREMENT = 'half-hourly'
-    DEFAULT_HORIZON = 100
-    DEFAULT_SIMULATION_SEED = 12345
-    DEFAULT_ASIN_SELECTION = 0
-    DEFAULT_PROFILE = 'national_grid_profile'
-    DEFAULT_NUM_BATTERIES = 10
-    DEFAULT_MAX_BATTERY_CAPACITY = 50
-    DEFAULT_BATTERY_PENALTY = 500
 
-    def __init__(self, simulation_seed=DEFAULT_SIMULATION_SEED,
-                 start_date=DEFAULT_START_DATE,
-                 time_increment=DEFAULT_TIME_INCREMENT,
-                 time_horizon=DEFAULT_HORIZON,
-                 num_batteries=DEFAULT_NUM_BATTERIES,
-                 max_battery_capacity=DEFAULT_MAX_BATTERY_CAPACITY,
-                 battery_penalty=DEFAULT_BATTERY_PENALTY):
 
+    def __init__(
+        self,
+        simulation_seed=DEFAULT_RUN_PARAMETERS.simulation_seed,
+        start_date=DEFAULT_RUN_PARAMETERS.start_date,
+        time_increment=DEFAULT_RUN_PARAMETERS.time_increment,
+        time_horizon=DEFAULT_RUN_PARAMETERS.time_horizon,
+        num_batteries=DEFAULT_RUN_PARAMETERS.num_batteries,
+        max_battery_capacity=DEFAULT_RUN_PARAMETERS.max_battery_capacity,
+        battery_penalty=DEFAULT_RUN_PARAMETERS.battery_penalty
+        ):
+
+        self.profile = DEFAULT_RUN_PARAMETERS.run_profile
+        self.asin_selection = DEFAULT_RUN_PARAMETERS.asin_selection
         self.simulation_seed = simulation_seed
         self.start_date = start_date
         self.time_increment = time_increment
@@ -33,8 +31,8 @@ class miniSCOTnotebook():
                    time_increment=self.time_increment,
                    time_horizon=self.time_horizon,
                    num_batteries=self.num_batteries,
-                   asin_selection=self.DEFAULT_ASIN_SELECTION,
-                   profile=self.DEFAULT_PROFILE,
+                   asin_selection=self.asin_selection,
+                   profile=self.profile,
                    max_battery_capacity=self.max_battery_capacity,
                    battery_penalty=self.battery_penalty)
 


### PR DESCRIPTION
Previously, default run parameters were being set in multiple different locations. The purpose of this work was to centralise these.

All default run parameters should now be specified in the appropriate module in `src/scse/default_run_parameters`. Note that `core_default_run_parameters` is inherited by module-specific default run parameter modules, which can override the core defaults if needed.
