### PR TITLE
Realistic reward values and integrated penalties in metrics file

### DIFF
--- a/src/scse/default_run_parameters/national_grid_default_run_parameters.py
+++ b/src/scse/default_run_parameters/national_grid_default_run_parameters.py
@@ -2,18 +2,21 @@ from dataclasses import dataclass
 
 from scse.default_run_parameters.core_default_run_parameters import CoreRunParameters
 
+
 @dataclass
 class _RunParameters(CoreRunParameters):
     # Override certain core parameters
     run_profile = 'national_grid_profile'
     asin_selection = 0  # Use 0 for national grid simulation
-    logging_level = 'DEBUG'  # May need to set to critical occassionally
+    logging_level = 'DEBUG'  #  May need to set to critical occassionally
     time_increment = 'half-hourly'
-    time_horizon = 336  # 1 week, if 30 min time increments
+    time_horizon = 336  #  1 week, if 30 min time increments
 
     # Bespoke parameters
     simulation_logging_level = 'CRITICAL'
     num_batteries = 1
     max_battery_capacity = 50
-    battery_penalty = 500
+    battery_penalty = 5000
+
+
 DEFAULT_RUN_PARAMETERS = _RunParameters()

--- a/src/scse/metrics/national_grid_cash_accounting.py
+++ b/src/scse/metrics/national_grid_cash_accounting.py
@@ -17,8 +17,8 @@ class CashAccounting():
 
         # TODO: play with different weights on the penalties!
 
-        self._cost = 10 * 3  # 5
-        self._price = 5  # 10
+        self._cost = 149.8
+        self._price = 32.0
         # self._cost = 5
         # self._price = 10
         self._transfer_cost = 0  # 2 # cost to move from the batteries


### PR DESCRIPTION
Source and sink calls penalised according to existing BMRS data values (in £/MWh) 

Modified battery penalty to be in the same metrics file as other reward penalties (thanks Alan for the suggestion!) 