### PR TITLE
Amortise battery cost over asset lifetime

### DIFF
--- a/src/scse/controller/miniscot.py
+++ b/src/scse/controller/miniscot.py
@@ -167,7 +167,9 @@ class SupplyChainEnvironment:
         logger.debug("trying to reset signed-in services")
         registry.reset_signed_in_services(context)
 
-        self.episode_reward += self._metrics._upfront_battery_cost
+        # Removing up-front battery cost - benefits longer simulations runtimes
+        # Moved to assuming amortized cost over asset lifetime
+        # self.episode_reward += self._metrics._upfront_battery_cost
 
         self._miniscot_time_profile["miniscot_action_execution"] = 0
         self._miniscot_time_profile["miniscot_advance_time"] = 0

--- a/src/scse/default_run_parameters/national_grid_default_run_parameters.py
+++ b/src/scse/default_run_parameters/national_grid_default_run_parameters.py
@@ -29,19 +29,10 @@ class _RunParameters(CoreRunParameters):
 
     # for now, assumes all batteries are of same capacity
     # TODO: modify to handle capacity which scales with cost
-
-    '''
-    potential battery types:
-    - tesla's megapack (£735916.40, capacity = 15 MWh)
-        - https://electrek.co/2020/07/06/tesla-deploys-megapack-autobidder/
-        - https://electrek.co/2021/07/26/tesla-reveals-megapack-prices/
-    '''
-    # battery_penalty = 735916.40  # units in £s
-    # max_battery_capacity = 15  # 1000  #  units in MWh
-    # using stat of ~$150/kWh => ~$150,000/MWh
-    battery_penalty = 110387.46  # units in £s
-    max_battery_capacity = 1  # 1000  #  units in MWh
-    init_battery_capacity = int(max_battery_capacity * 0.2)  # 0.2)
+    max_battery_capacity = 50  # 1000  #  units in MWh
+    init_battery_charge_frac = 0.2  # 0.2
+    battery_penalty = 200 * 1000 # units in £/MWh
+    lifetime_years = 10 # number of years over which price is spread
 
 
 DEFAULT_RUN_PARAMETERS = _RunParameters()

--- a/src/scse/metrics/national_grid_cash_accounting.py
+++ b/src/scse/metrics/national_grid_cash_accounting.py
@@ -157,6 +157,8 @@ class CashAccounting():
             reward = transfer_revenue  #  positive = good
 
         elif actionType == 'advance_time':
+            # Make sure to see code + comments at the end of this block
+
             reward = {}
             reward_by_asin = {k: 0 for k in self._context['asin_list']}
             reward['total'] = 0
@@ -165,6 +167,7 @@ class CashAccounting():
             G = state['network']
 
             # accounts for cost w/ keeping energy in the batteries
+            # subtracted from total cost at the end of this block
             for node, node_data in G.nodes(data=True):
                 if node_data['node_type'] == 'warehouse':
                     for asin in G.nodes[node]['inventory']:
@@ -214,8 +217,12 @@ class CashAccounting():
                     writer = csv.writer(f)
                     writer.writerows(self._metrics_log)
 
+            # Subtract cost of inventory at hand from total cost
             reward['total'] -= total_holding_cost
+
+            # Per-period payback of amortised battery CAPEX costs
             reward['total'] += self._amortised_battery_cost
+
             reward['by_asin'] = reward_by_asin
 
         else:

--- a/src/scse/metrics/national_grid_cash_accounting.py
+++ b/src/scse/metrics/national_grid_cash_accounting.py
@@ -74,8 +74,16 @@ class CashAccounting():
         # penalty scaled by capacity of battery
         # TODO: check that this makes sense
         G = state["network"]
-        self._upfront_battery_cost = self._battery_penalty * self._max_battery_capacity * self._num_batteries
-        self._amortised_battery_cost = self._upfront_battery_cost / (self._lifetime_years * 365 * 24 * 2)
+
+        # Total battery CAPEX, ignoring discounting
+        self._upfront_battery_cost = (
+            self._battery_penalty * self._max_battery_capacity * self._num_batteries
+        )
+        # Amortise battery CAPEX over lifetime
+        # Even installments every simulation period (30 mins)
+        self._amortised_battery_cost = (
+            self._upfront_battery_cost / (self._lifetime_years * 365 * 24 * 2)
+        )
 
         # We'll use this to track unfilled demand, since this builds up
         self._cumulative_customer_orders = []

--- a/src/scse/modules/topology/national_grid_network_dynamic.py
+++ b/src/scse/modules/topology/national_grid_network_dynamic.py
@@ -30,8 +30,8 @@ class NationalGridNetwork(Env):
             'transit_time', self._DEFAULT_TRANSIT_TIME)
         self._max_battery_capacity = run_parameters.get(
             'max_battery_capacity', DEFAULT_RUN_PARAMETERS.max_battery_capacity)
-        self._init_battery_capacity = run_parameters.get(
-            'init_battery_capacity', DEFAULT_RUN_PARAMETERS.init_battery_capacity)
+        self._init_battery_charge_frac = run_parameters.get(
+            '_init_battery_charge_frac', DEFAULT_RUN_PARAMETERS.init_battery_charge_frac)
 
         self._num_batteries = run_parameters.get(
             'num_batteries', DEFAULT_RUN_PARAMETERS.num_batteries)
@@ -138,7 +138,10 @@ class NationalGridNetwork(Env):
                        node_type='warehouse',
                        location=battery_loc,
                        inventory={
-                           ELECTRICITY_ASIN: self._init_battery_capacity},
+                           ELECTRICITY_ASIN: int(
+                               self._init_battery_charge_frac * self._max_battery_capacity
+                            )
+                        },
                        max_inventory={
                            ELECTRICITY_ASIN: self._max_battery_capacity}
                        )


### PR DESCRIPTION
Using the total battery CAPEX as an upfront penalty at the beginning of simulations leads to time-dependant behaviour, as indicated by the naive example below. If the simulation is run for longer larger number of batteries will have paid themselves off, and so the BO loop will increasingly favour larger volumes of batteries.

![image](https://user-images.githubusercontent.com/32013626/148742388-36979d24-16b2-4824-a6a9-0b83a9290440.png)

We wanted to remove this behaviour, which also isn't reflective of how CAPEX is funded in reality. Instead, we now amortise the cost of the batteries over their lifetime. Thus, a fraction of the CAPEX is paid in each period.

In this PR, batteries have been assumed to have a 10 year lifetime. Manufacturers frequently claim longer lifetimes than this (up to 25 years), however the lower figure can be used to incorporate OPEX, and the likelihood of replacing the batteries with newer, more efficient models before the end of their lifetime.