### PR TITLE
Removing artificial overdemand at initialisation

### DIFF
--- a/src/scse/default_run_parameters/national_grid_default_run_parameters.py
+++ b/src/scse/default_run_parameters/national_grid_default_run_parameters.py
@@ -18,9 +18,9 @@ class _RunParameters(CoreRunParameters):
 
     # Penalty and reward prices, w/ units £/MWh
     source_request_reward_penalty = -36.65
-    sink_deposit_reward_penalty = 27.63
+    sink_deposit_reward_penalty = -36.65 # -27.63
     battery_drawdown_reward_penalty = 36.65
-    battery_charging_reward_penalty = -27.63
+    battery_charging_reward_penalty = 36.65 # -27.63
 
     # Other penalties
     transfer_penalty = 0  # 2
@@ -31,7 +31,7 @@ class _RunParameters(CoreRunParameters):
     # TODO: modify to handle capacity which scales with cost
     max_battery_capacity = 50  # 1000  #  units in MWh
     init_battery_charge_frac = 0.2  # 0.2
-    battery_penalty = 200 * 1000 # units in £/MWh
+    battery_penalty = -(200 * 1000) # units in £/MWh
     lifetime_years = 10 # number of years over which price is spread
 
 

--- a/src/scse/metrics/national_grid_cash_accounting.py
+++ b/src/scse/metrics/national_grid_cash_accounting.py
@@ -72,7 +72,6 @@ class CashAccounting():
 
         # penalize the use of many batteries
         # penalty scaled by capacity of battery
-        # TODO: check that this makes sense
         G = state["network"]
 
         # Total battery CAPEX, ignoring discounting
@@ -147,6 +146,7 @@ class CashAccounting():
             # case 1: charge battery_idx
             if action['origin'] == "Substation" and "Battery" in action["destination"]:
                 transfer_revenue = self._battery_charging * quantity
+
             # case 2: discharge/drawdown electricity from battery
             # cost of charging a battery
             if action['destination'] == "Substation" and "Battery" in action["origin"]:
@@ -221,7 +221,9 @@ class CashAccounting():
             reward['total'] -= total_holding_cost
 
             # Per-period payback of amortised battery CAPEX costs
-            reward['total'] += self._amortised_battery_cost
+            # No charge for 0th simulation stage
+            if state['clock'] != 0:
+                reward['total'] += self._amortised_battery_cost
 
             reward['by_asin'] = reward_by_asin
 

--- a/src/scse/metrics/national_grid_cash_accounting.py
+++ b/src/scse/metrics/national_grid_cash_accounting.py
@@ -221,7 +221,7 @@ class CashAccounting():
             reward['total'] -= total_holding_cost
 
             # Per-period payback of amortised battery CAPEX costs
-            # No charge for 0th simulation stage
+            # No penalty for 0th simulation stage
             if state['clock'] != 0:
                 reward['total'] += self._amortised_battery_cost
 

--- a/src/scse/modules/customer/national_grid_demand.py
+++ b/src/scse/modules/customer/national_grid_demand.py
@@ -41,8 +41,11 @@ class ElectricityDemand(Agent):
         """
         actions = []
         current_time = state['date_time']
+        current_clock = state['clock']
 
-        forecasted_demand = self._demand_forecast_service.get_forecast(current_time)
+        forecasted_demand = self._demand_forecast_service.get_forecast(
+            clock=current_clock, time=current_time
+        )
 
         action = {
             'type': 'customer_order',

--- a/src/scse/modules/placement/national_grid_balance_excess_demand.py
+++ b/src/scse/modules/placement/national_grid_balance_excess_demand.py
@@ -55,7 +55,10 @@ class BalanceExcessDemand(Agent):
         for node, node_data in G.nodes(data=True):
             if node_data.get('node_type') in ['port']:
                 # Would want to pass the node as an argument to the service, in due time
-                future_demand = self._demand_forecast_service.get_forecast(time=next_time)
+                future_demand = self._demand_forecast_service.get_forecast(
+                    clock=current_clock,
+                    time=next_time
+                )
 
                 # Current capacity should be zero most of the time, as long as the balance
                 # mechanism source is in use.

--- a/src/scse/modules/placement/national_grid_battery_drawdown.py
+++ b/src/scse/modules/placement/national_grid_battery_drawdown.py
@@ -55,7 +55,9 @@ class BatteryDrawdown(Agent):
             if node_data.get('node_type') in ['port']:
                 # Would want to pass the node as an argument to the service, in due time
                 future_demand = self._demand_forecast_service.get_forecast(
-                    time=next_time)
+                    clock=current_clock,
+                    time=next_time
+                )
 
                 # Current capacity should be zero most of the time.
                 # Deviations will occur when battery capacity falls to zero.

--- a/src/scse/modules/vendor/national_grid_supply.py
+++ b/src/scse/modules/vendor/national_grid_supply.py
@@ -68,7 +68,9 @@ class ElectricitySupply(Agent):
                     raise ValueError('All sources must have only one generation type - multiple not yet supported.')
                 
                 generation_type = generation_types[0]
-                forecasted_supply = self._supply_forecast_service.get_forecast(generation_type, current_time)
+                forecasted_supply = self._supply_forecast_service.get_forecast(
+                    asin=generation_type, clock=current_clock, time=current_time
+                )
                 
                 logger.debug(f"Supply for {forecasted_supply} quantity of ASIN {generation_type}.")
 

--- a/src/scse/services/electricity_demand_forecast_service.py
+++ b/src/scse/services/electricity_demand_forecast_service.py
@@ -28,7 +28,7 @@ class ElectricityDemandForecast(Service):
         logger.debug("Resetting electricity demand forecast service.")
         pass
 
-    def get_forecast(self, time):
+    def get_forecast(self, clock, time):
         """
         Generate a demand forcast for the given time.
 
@@ -39,6 +39,11 @@ class ElectricityDemandForecast(Service):
         i.e. the same forecast is returned when the same arguments
         are passed.
         """
+
+        # No demand for the 0th simulation period
+        # There is no supply in the -1th period
+        if clock == 0:
+            return 0
 
         # Determine which period of the day is being considered
         # Date information is not yet being used

--- a/src/scse/services/electricity_supply_forecast_service.py
+++ b/src/scse/services/electricity_supply_forecast_service.py
@@ -33,7 +33,7 @@ class ElectricitySupplyForecast(Service):
         if self._asin_list != context['asin_list']:
             self._asin_list = context['asin_list']
             
-    def get_forecast(self, asin, time):
+    def get_forecast(self, asin, clock, time):
         """
         Generate a supply forcast for the given ASIN/electricity generation
         type, and the given time.


### PR DESCRIPTION
Previously the simulation was incurring an artificially high penalty at time instance 0 of the simulation. This was being caused by demand being put on the substation before any supply had been sent (given that suppliers/electricity generators were not operational at time instance -1, and so had not sent any electricity to the substation).

This is simply corrected by enforcing zero demand at time instance 0. Similarly, the battery penalty for time instance zero has been set to 0.

Finally, correction to battery penalty: this should have been negative.