### PR TITLE
Fixing Battery Drawdown Bug

### DIFF
--- a/src/scse/modules/placement/national_grid_battery_drawdown.py
+++ b/src/scse/modules/placement/national_grid_battery_drawdown.py
@@ -116,18 +116,15 @@ class BatteryDrawdown(Agent):
         # - Substations with the greatest predicted deficit are serviced first
         # - Electricity is drawn down from the closest batteries first
         for substation in list(substations.keys()):
-            # Starting deficit figure
-            future_deficit = substations[substation]
-
             for battery in list(batteries.keys()):
                 # Initial available capacity
                 battery_capacity = batteries[battery]
 
                 # If capacity exceeds the substation's forcasted deficit then fully meet that deficit
                 # Otherwise, drain the battery and remove it from the list
-                if battery_capacity >= future_deficit:
-                    drawdown_amount = future_deficit
-                    batteries[battery] -= future_deficit
+                if battery_capacity >= substations[substation]:
+                    drawdown_amount = substations[substation]
+                    batteries[battery] -= substations[substation]
                 else:
                     drawdown_amount = battery_capacity
                     del batteries[battery]
@@ -151,7 +148,7 @@ class BatteryDrawdown(Agent):
                 actions.append(action)
 
                 # If the substation's deficit has now bene met then break
-                if future_deficit == 0:
+                if substations[substation] == 0:
                     del substations[substation]
                     logger.debug(
                         f"Met supply deficit at substation {substation} in next timestep.")


### PR DESCRIPTION
**Bug Description:** When we draw down from batteries we attempt to take the total shortfall in the network from each battery individually. This isn't a problem if the shortfall exceeds the total battery capacity, but as the total capacity increases we'd increasingly be able to meet it and still have some charge left. It's difficult to spot because if we've accidentally created excess supply in the network, which gets sent back to the batteries again in the next timestep. Assuming all other supply and demand was zero in that timestep, based on the current reward and penalty values in the main branch we'd reward ourself £3.20 per MWh that does the return journey.

**Example:** say the total deficit in the network is 45 MWh. If we have 50 100 MWh batteries with full charge then we'd sent 45 MWh from each of those, i.e. 45*50=2250 MWh. If we instead had 100 50 MWh batteries with full charge then we'd send 100*45=4500 MWh.

Hence why batteries with smaller individual capacity had a higher reward in the below graph.

![image](https://user-images.githubusercontent.com/32013626/149841880-558df859-8050-42ea-830a-3d9c8f749a7c.png)

**Bug Impact:** The errors in the reward value introduced by this bug over the time period of week seem to be in the order of 10^4, so two orders of magnitude smaller than the 10^6 that the reward function varies over - the well it created in the solution space was very small. However, this would grow as the time period is extended - the gap between the lines in the graph above would increase.